### PR TITLE
feat: add grouping to markdown output

### DIFF
--- a/lib/checkout.ts
+++ b/lib/checkout.ts
@@ -4,7 +4,7 @@ import { CrawlConfig } from "./models";
 export async function checkout(config: CrawlConfig) {
   await git([`checkout`, config.gitTag]);
   const date = await git([`log -1 --format=%ai ${config.gitTag}`]);
-  return date;
+  return date.replace("\r\n", '').replace("\n", '');
 }
 
 function git(args: string[]): Promise<string> {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -95,5 +95,7 @@ export interface Deprecation {
   code: string;
   deprecationMessage: string;
   pos: [number, number];
+
   group?: string;
+  uuid?: string;
 }

--- a/lib/output-formatters/add-comments-to-repository.ts
+++ b/lib/output-formatters/add-comments-to-repository.ts
@@ -1,10 +1,10 @@
 import { Project } from "ts-morph";
 import { CrawlConfig, Deprecation } from "../models";
-import { hash, EOL, DEPRECATIONLINK, DEPRECATION } from "../utils";
+import { EOL, DEPRECATIONLINK, DEPRECATION } from "../utils";
 import { cwd } from "process";
 import { join } from "path";
 
-export function addCommentToRepository(
+export async function addCommentToRepository(
   config: CrawlConfig,
   rawDeprecations: Deprecation[]
 ) {
@@ -23,7 +23,7 @@ export function addCommentToRepository(
   }, {} as { [filePath: string]: Deprecation[] });
 
   Object.entries(deprecationsByFile).forEach(([path, deprecations]) => {
-    console.log(`🔧 ${path.substr(1)}`);
+    console.log(`🔧 ${path}`);
 
     let addedPosForText = 0;
 
@@ -33,9 +33,7 @@ export function addCommentToRepository(
       const filePath = join(cwd(), path);
 
       const sourceFile = project.getSourceFile(filePath);
-      const deprecationDetails = ` Details: {@link ${DEPRECATIONLINK}#${hash(
-        deprecation.code
-      )}}`;
+      const deprecationDetails = ` Details: {@link ${DEPRECATIONLINK}#${deprecation.uuid}}`;
 
       const lines = deprecation.deprecationMessage.split(EOL);
       const newText = lines

--- a/lib/output-formatters/generate-markdown.ts
+++ b/lib/output-formatters/generate-markdown.ts
@@ -1,9 +1,9 @@
 import { writeFileSync } from "fs";
 import { basename, join } from "path";
 import { CrawlConfig, Deprecation } from "../models";
-import { ensureDirExists, EOL, hash } from "../utils";
+import { ensureDirExists, EOL } from "../utils";
 
-export function generateMarkdown(
+export async function generateMarkdown(
   config: CrawlConfig,
   rawDeprecations: Deprecation[],
   options: { tagDate: string }
@@ -17,33 +17,44 @@ export function generateMarkdown(
 
   console.log("📝 Generating markdown");
 
-  const deprecationsByFile = rawDeprecations.reduce((acc, val) => {
-    acc[val.path] = (acc[val.path] || []).concat(val);
+  const deprecationsByGroup = rawDeprecations.reduce((acc, val) => {
+    const group = val.group || "";
+    acc[group] = (acc[group] || []).concat(val);
     return acc;
-  }, {} as { [filePath: string]: Deprecation[] });
+  }, {} as { [group: string]: Deprecation[] });
 
-  const pagesInMd = Object.entries(deprecationsByFile).map(
-    ([path, deprecations]) => {
-      const sorted = deprecations.sort((a, b) =>
-        a.pos[0] > b.pos[0] ? 1 : -1
+  const pagesInMd = Object.entries(deprecationsByGroup).map(
+    ([deprecationGroup, groupedDeprecations]) => {
+      const deprecationsByFile = groupedDeprecations.reduce((acc, val) => {
+        acc[val.path] = (acc[val.path] || []).concat(val);
+        return acc;
+      }, {} as { [filePath: string]: Deprecation[] });
+
+      const deprecationsOrdered = Object.entries(deprecationsByFile).map(
+        ([path, deprecations]) => {
+          const sorted = deprecations.sort((a, b) =>
+            a.pos[0] > b.pos[0] ? 1 : -1
+          );
+
+          return ["", `### ${basename(path)}`].concat(
+            ...sorted.map((deprecation) => {
+              return [
+                "",
+                `#### ${deprecation.name} (${deprecation.kind}) {#${deprecation.uuid}}`,
+                "",
+                stripComment(deprecation.deprecationMessage),
+                "",
+                "```ts",
+                deprecation.code,
+                "```",
+              ];
+            })
+          );
+        }
       );
 
-      return [`## ${basename(path)}`, ""]
-        .concat(
-          sorted.map((deprecation) => {
-            return [
-              `### ${deprecation.name} (${deprecation.kind}) {" #${hash(
-                deprecation.code
-              )}}`,
-              "",
-              stripComment(deprecation.deprecationMessage),
-              "",
-              "```ts",
-              deprecation.code,
-              "```",
-            ].join(EOL);
-          })
-        )
+      return [`## ${deprecationGroup}`]
+        .concat(...deprecationsOrdered)
         .join(EOL);
     }
   );

--- a/lib/output-formatters/generate-raw-json.ts
+++ b/lib/output-formatters/generate-raw-json.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { CrawlConfig, Deprecation } from "../models";
 import { ensureDirExists } from "../utils";
 
-export function generateRawJson(
+export async function generateRawJson(
   config: CrawlConfig,
   rawDeprecations: Deprecation[],
   options: { tagDate: string }

--- a/lib/processors/unique.ts
+++ b/lib/processors/unique.ts
@@ -1,0 +1,16 @@
+import { CrawlConfig, Deprecation } from "../models";
+import { hash } from '../utils';
+
+export async function addUniqueKey(
+  config: CrawlConfig,
+  rawDeprecations: Deprecation[]
+): Promise<Deprecation[]> {
+  if (rawDeprecations.length === 0) {
+    return rawDeprecations;
+  }
+
+  console.log("Adding uuid to deprecations...");
+  return rawDeprecations.map(deprecation => {
+    return {...deprecation, uuid: hash( deprecation.code)}
+  })
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,7 +18,7 @@ export function hash(str: string) {
   /* JavaScript does bitwise operations (like XOR, above) on 32-bit signed
    * integers. Since we want the results to be always positive, convert the
    * signed int to an unsigned by doing an unsigned bitshift. */
-  return hash >>> 0;
+  return (hash >>> 0).toString();
 }
 
 export function ensureDirExists(dir: string) {


### PR DESCRIPTION
- add grouping to markdown
- move hash to a `unique` processor (and add it to the deprecation, this means it will also be saved in the JSON file)
- some markup cleanups

cc @BioPhoton 